### PR TITLE
Prepare for release v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/klog/v2 v2.8.0
 	kmodules.xyz/client-go v0.0.0-20210617233340-13d22e91512b
 	kubeform.dev/apimachinery v0.0.0-20210629153539-7bcd34a30eb5
-	kubeform.dev/provider-dynatrace-api v0.0.0-20210802154200-b7300b52ab3e
+	kubeform.dev/provider-dynatrace-api v0.3.0
 	sigs.k8s.io/cli-utils v0.25.0
 	sigs.k8s.io/controller-runtime v0.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1139,8 +1139,8 @@ kmodules.xyz/resource-metadata v0.5.7 h1:5xjq5pEp5hZK+jdkY/4wGk/FMtTyvQ9LlErh7lQ
 kmodules.xyz/resource-metadata v0.5.7/go.mod h1:Jdi7zBXRwwFTOR0CxwKxqJhsDVIilhrgNipPjnKLyrs=
 kubeform.dev/apimachinery v0.0.0-20210629153539-7bcd34a30eb5 h1:kpCzsugm64OMYV9ywBIOXbGN7z5ifK+rnGln+f3Gct4=
 kubeform.dev/apimachinery v0.0.0-20210629153539-7bcd34a30eb5/go.mod h1:kfiYdu87pCcrydTGaLXs4QMFx1fLNP5Yov2KxgrkCm0=
-kubeform.dev/provider-dynatrace-api v0.0.0-20210802154200-b7300b52ab3e h1:QjmWQyxrUf/XfSu8D26y2VKjMdaHjoux1OgJAWQNToA=
-kubeform.dev/provider-dynatrace-api v0.0.0-20210802154200-b7300b52ab3e/go.mod h1:NcuM5lwm2LjciY08AH0YgfpT+wIvht+9ZygbVw8msv0=
+kubeform.dev/provider-dynatrace-api v0.3.0 h1:m7/POh79qvHg7N6nYPzbcwxhfYfMiJ0CLXSrK0zZsoM=
+kubeform.dev/provider-dynatrace-api v0.3.0/go.mod h1:NcuM5lwm2LjciY08AH0YgfpT+wIvht+9ZygbVw8msv0=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -953,7 +953,7 @@ kmodules.xyz/resource-metadata/pkg/graph
 # kubeform.dev/apimachinery v0.0.0-20210629153539-7bcd34a30eb5
 ## explicit
 kubeform.dev/apimachinery/api/v1alpha1
-# kubeform.dev/provider-dynatrace-api v0.0.0-20210802154200-b7300b52ab3e
+# kubeform.dev/provider-dynatrace-api v0.3.0
 ## explicit
 kubeform.dev/provider-dynatrace-api/api/provider
 kubeform.dev/provider-dynatrace-api/apis/alerting


### PR DESCRIPTION
ProductLine: Kubeform
Release: v2021.08.02
Release-tracker: https://github.com/kubeform/CHANGELOG/pull/14
Signed-off-by: 1gtm <1gtm@appscode.com>